### PR TITLE
Fix types & unprotect onQueryMore/onMutate

### DIFF
--- a/packages/mst-query/src/create.ts
+++ b/packages/mst-query/src/create.ts
@@ -1,4 +1,4 @@
-import { types, IAnyType, toGeneratorFunction, flow, SnapshotIn, Instance } from 'mobx-state-tree';
+import { types, IAnyType, flow, SnapshotIn, Instance } from 'mobx-state-tree';
 import { MstQueryHandler } from './MstQueryHandler';
 
 type TypeOrFrozen<T> = T extends IAnyType ? T : ReturnType<typeof types.frozen>;
@@ -177,3 +177,7 @@ export function createMutation<TData extends IAnyType, TRequest extends IAnyType
 export const VolatileQuery = createQuery('VolatileQuery', {});
 
 export interface VolatileQueryType extends Instance<typeof VolatileQuery> {}
+
+export type QueryReturnType = ReturnType<typeof createQuery>;
+
+export type MutationReturnType = ReturnType<typeof createMutation>;

--- a/packages/mst-query/src/hooks.ts
+++ b/packages/mst-query/src/hooks.ts
@@ -1,13 +1,6 @@
-import {
-    getSnapshot,
-    getType,
-    IAnyType,
-    Instance,
-    isStateTreeNode,
-    SnapshotIn,
-} from 'mobx-state-tree';
+import { getSnapshot, getType, Instance, isStateTreeNode, SnapshotIn } from 'mobx-state-tree';
 import { useContext, useEffect, useRef, useState } from 'react';
-import { createQuery, createMutation, VolatileQuery } from './create';
+import { VolatileQuery, MutationReturnType, QueryReturnType } from './create';
 import { Context } from './QueryClientProvider';
 import { QueryClient } from './QueryClient';
 import { EmptyPagination, EmptyRequest, QueryObserver } from './MstQueryHandler';
@@ -19,10 +12,6 @@ function mergeWithDefaultOptions(key: string, options: any, queryClient: QueryCl
         ...options,
     });
 }
-
-export type QueryReturnType = ReturnType<typeof createQuery>;
-
-export type MutationReturnType = ReturnType<typeof createMutation>;
 
 type QueryOptions<T extends Instance<QueryReturnType>> = {
     request?: SnapshotIn<T['variables']['request']>;

--- a/packages/mst-query/tests/api/api.ts
+++ b/packages/mst-query/tests/api/api.ts
@@ -31,4 +31,7 @@ export const api = {
             description: 'add',
         };
     },
+    async removeItem({ request }: any) {
+        return request.id;
+    }
 };

--- a/packages/mst-query/tests/models/RemoveItemMutation.ts
+++ b/packages/mst-query/tests/models/RemoveItemMutation.ts
@@ -1,0 +1,10 @@
+import { types } from 'mobx-state-tree';
+import { createMutation } from '../../src';
+import { ItemModel } from './ItemModel';
+import { api } from '../api/api';
+
+export const RemoveItemMutation = createMutation('RemoveMutation', {
+    data: types.reference(ItemModel),
+    request: types.model({ id: types.string }),
+    endpoint: api.removeItem
+});

--- a/packages/mst-query/tests/models/RootStore.ts
+++ b/packages/mst-query/tests/models/RootStore.ts
@@ -1,4 +1,4 @@
-import { IAnyModelType, Instance, types } from 'mobx-state-tree';
+import { destroy, IAnyModelType, Instance, types } from 'mobx-state-tree';
 import { createQuery } from '../../src/create';
 import { onMutate } from '../../src/MstQueryHandler';
 import { createModelStore, createRootStore } from '../../src/stores';
@@ -12,6 +12,7 @@ import { SetDescriptionMutation } from './SetDescriptionMutation';
 import { UserModel } from './UserModel';
 import { ArrayQuery } from './ArrayQuery';
 import { SafeReferenceQuery } from './SafeReferenceQuery';
+import { RemoveItemMutation } from './RemoveItemMutation';
 
 export const DateModel = types.model('DateModel', {
     id: types.identifier,
@@ -71,6 +72,7 @@ const ItemServiceStore = types
         itemQuery: optional(ItemQuery),
         itemQuery2: optional(ItemQuery),
         addItemMutation: optional(AddItemMutation),
+        removeItemMutation: optional(RemoveItemMutation),
         setDescriptionMutation: optional(SetDescriptionMutation),
         listQuery: optional(ListQuery),
         arrayQuery: optional(ArrayQuery),
@@ -80,8 +82,11 @@ const ItemServiceStore = types
     })
     .actions((self) => ({
         afterCreate() {
-            onMutate(self.addItemMutation, (data: any) => {
+            onMutate(self.addItemMutation, (data) => {
                 self.listQuery.data?.addItem(data);
+            });
+            onMutate(self.removeItemMutation, (data) => {
+                destroy(data);
             });
         },
     }));

--- a/packages/mst-query/tests/mstQuery.test.tsx
+++ b/packages/mst-query/tests/mstQuery.test.tsx
@@ -821,8 +821,9 @@ test('safeReference', async () => {
 
     expect(q.safeReferenceQuery.data?.items.length).toBe(4);
 
-    unprotect(getRoot(q));
-    destroy(rootStore.itemStore.models.get('test'));
+    q.removeItemMutation.mutate({ request: { id: 'test' }});
+
+    await wait(0);
 
     expect(q.safeReferenceQuery.data?.items.length).toBe(3);
 


### PR DESCRIPTION
Fixes types for onQueryMore & onMutate and allow them to modify properties directly in the callback (this should use an action, but I'm not sure right now how to handle that).